### PR TITLE
add whitelist urls to env file

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,9 @@
 # Your Hypixel secret key, see https://developer.hypixel.net/
 HYPIXEL_SECRET_KEY=
 
-
+# URLs of your 25karma frontend (whitelist)
+# Format: "[url] [url] ..." (space-separated). e.g "https://25karma.xyz http://localhost:3000"
+FRONTEND_URLS=""
 
 ####################################
 # ↓ OPTIONAL ENVIRONMENT VARIABLES ↓

--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ HYPIXEL_SECRET_KEY=
 
 # URLs of your 25karma frontend (whitelist)
 # Format: "[url] [url] ..." (space-separated). e.g "https://25karma.xyz http://localhost:3000"
-FRONTEND_URLS=""
+WHITELISTED_URLS=
 
 ####################################
 # ↓ OPTIONAL ENVIRONMENT VARIABLES ↓

--- a/middlewares/cors.js
+++ b/middlewares/cors.js
@@ -1,6 +1,6 @@
 import expressCors from 'cors';
 
-const whitelist = [];
+const whitelist = process.env.FRONTEND_URLS.split(' ')
 
 export function cors() {
 	const options = {

--- a/middlewares/cors.js
+++ b/middlewares/cors.js
@@ -5,7 +5,7 @@ const whitelist = process.env.WHITELISTED_URLS;
 
 export function cors() {
 	const options = {
-		origin: whitelist,
+		origin: whitelist !== undefined ? whitelist.split(SEPARATOR) : '*',
 	};
 	return expressCors(options);
 }

--- a/middlewares/cors.js
+++ b/middlewares/cors.js
@@ -1,6 +1,7 @@
 import expressCors from 'cors';
 
-const whitelist = process.env.FRONTEND_URLS.split(' ')
+const SEPARATOR = ' ';
+const whitelist = process.env.WHITELISTED_URLS;
 
 export function cors() {
 	const options = {


### PR DESCRIPTION
previously, on a self hosted instance users would receive a cors error when fetching resources from their hosted instance.

now, there is a clear area in the .env to add whitelist urls which cors.js handles