### PR TITLE
Fix guild endpoint errors always assuming the player isn't in a guild

### DIFF
--- a/middlewares/guild.js
+++ b/middlewares/guild.js
@@ -1,12 +1,18 @@
 import { getHypixelGuild } from '../utils/requests';
+import { sendHypixelError } from '../utils/errors';
 
 export async function guild(req, res, next) { 
 	const slug = res.locals.slug;
 	const uuid = res.locals.mojang.uuid;
 	const json = await getHypixelGuild(uuid);
-	res.locals.guild = json.guild;
-	if (!res.locals.guild && req.route.path === '/guild/:slug') {
-		return res.send({success: false, slug, reason: 'HYPIXEL_GUILD_DNE'});
+
+	if (json.response === 200) {
+		res.locals.guild = json.guild;
+		if (!res.locals.guild && req.route.path === '/guild/:slug') {
+			return res.send({success: false, slug, reason: 'HYPIXEL_GUILD_DNE'});
+		}
 	}
+	else return sendHypixelError(res, slug, json.response);
+
 	next();
 }

--- a/middlewares/player.js
+++ b/middlewares/player.js
@@ -1,6 +1,7 @@
 import { memjsClient } from '../utils/caches';
 import * as filters from '../utils/filters';
 import { getHypixelPlayer } from '../utils/requests';
+import { sendHypixelError } from '../utils/errors';
 
 export async function player(req, res, next) {
 	// Call the Hypixel API
@@ -34,10 +35,7 @@ export async function player(req, res, next) {
 			return res.send({success: false, slug, reason: 'HYPIXEL_PLAYER_DNE'});
 		}
 	}
-	else if (json.response === 403) return res.send({success: false, slug, reason: 'HYPIXEL_ACCESS_DENIED'});
-	else if (json.response === 429) return res.send({success: false, slug, reason: 'HYPIXEL_THROTTLED'});
-	else if (json.response >=  500) return res.send({success: false, slug, reason: 'HYPIXEL_DOWN'});
-	else                              return res.send({success: false, slug, reason: 'UNKNOWN'});
+	else return sendHypixelError(res, slug, json.response);
 	
 	next();
 }

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -1,0 +1,8 @@
+export function sendHypixelError(res, slug, code) {
+	let reason;
+	if (code === 403) reason = 'HYPIXEL_ACCESS_DENIED';
+	else if (code === 429) reason = 'HYPIXEL_THROTTLED';
+	else if (code >= 500) reason = 'HYPIXEL_DOWN';
+	else reason = 'UNKNOWN';
+	return res.send({ success: false, slug, reason });
+}


### PR DESCRIPTION
Before, an error when looking up a player's guild would always assume they weren't in a guild, even if it was the hypixel API being throttled or down.

I added a utility function to avoid duplicate code.