### PR TITLE
Replace playerdb.co with mowojang.seraph.si, lower extreme cache TTL

### DIFF
--- a/utils/caches.js
+++ b/utils/caches.js
@@ -38,7 +38,7 @@ function getActiveClient(client, key) {
 			client.set(
 				key, 
 				Buffer.from(JSON.stringify(val)), 
-				{expires: 30*24*60*60}); // If this changes, update the Tip.js file in 25Karma
+				{expires: 86400}); // If this changes, update the Tip.js file in 25Karma
 		},
 		close: () => {
 			client.close();

--- a/utils/requests.js
+++ b/utils/requests.js
@@ -7,8 +7,8 @@ export async function getMojang(slug) {
 	const json = await response.json();
 	return {
 		response: response.status,
-		username: json.name,
-		uuid: normalizeUUID(json.id),
+		username: json?.name,
+		uuid: normalizeUUID(json?.id),
 	};
 }
 
@@ -49,7 +49,7 @@ export async function getHypixelResource(endpoint) {
 }
 
 function normalizeUUID(uuid) {
-    if (!uuid.includes("-")) {
+    if (uuid && !uuid.includes("-")) {
         return [uuid.slice(0, 8), uuid.slice(8, 12), uuid.slice(12, 16), uuid.slice(16, 20), uuid.slice(20)].join('-')
     }
     return uuid;

--- a/utils/requests.js
+++ b/utils/requests.js
@@ -3,12 +3,12 @@ import fetch from 'node-fetch';
 const key = process.env.HYPIXEL_SECRET_KEY
 
 export async function getMojang(slug) {
-	const response = await fetch(`https://playerdb.co/api/player/minecraft/${slug}`);
+	const response = await fetch(`https://mowojang.seraph.si/${slug}`);
 	const json = await response.json();
 	return {
 		response: response.status,
-		username: traverse(json, 'data.player.username'),
-		uuid: traverse(json, 'data.player.id'),
+		username: json.name,
+		uuid: normalizeUUID(json.id),
 	};
 }
 
@@ -48,12 +48,9 @@ export async function getHypixelResource(endpoint) {
 	}
 }
 
-function traverse(json, path, defaultValue = undefined) {
-	const paths = path.split('.');
-	for (const p of paths) {
-		if (json === undefined) return defaultValue;
-		json = json[p];
-	}
-	if (json === undefined) return defaultValue;
-	return json;
+function normalizeUUID(uuid) {
+    if (!uuid.includes("-")) {
+        return [uuid.slice(0, 8), uuid.slice(8, 12), uuid.slice(12, 16), uuid.slice(16, 20), uuid.slice(20)].join('-')
+    }
+    return uuid;
 }


### PR DESCRIPTION
Playerdb.co takes a long time to update the usernames of players and is generally pretty slow. mowojang.seraph.si is simply just a proxy of the actual mojang API and a mirror of the well known mowojang.matdoes.dev but with better hardware.

Also the 30 day cache expiry is pretty overkill so I lowered it to 1 day as I don't see any reason for it to be that long. Its only causing issues when searching by username. I swapped a username between an account nearly a week ago and its still looking up the old account when putting the username in. Its not because the old account hasn't logged into hypixel since the name change because it has, it seems to be the extremely long cache's doing. According to the comment "If this changes, update the Tip.js file in 25Karma" you will have to update that file.